### PR TITLE
compile with -gsrc for full introspection

### DIFF
--- a/build.ss
+++ b/build.ss
@@ -31,7 +31,7 @@
      (let (depgraph (call-with-input-file "build-deps" read))
        (make srcdir: srcdir
              optimize: #t
-             debug: 'env
+             debug: 'src
              static: #t
              depgraph: depgraph
              prefix: "clan"


### PR DESCRIPTION
Changes the build to compile with -gsrc; this will allow pp and full introspection with `##decompile`.
