### PR TITLE
Added improved variants of `hash-merge` and `hash-merge!` functions f…

### DIFF
--- a/utils/hash.ss
+++ b/utils/hash.ss
@@ -12,8 +12,10 @@
   hash-ensure-removed!
   hash-ensure-modify
   hash-empty?
-  hash-merge
-  hash-merge!
+  hash-prefer-left
+  hash-prefer-left!
+  hash-prefer-right
+  hash-prefer-right!
   )
 
 (import
@@ -143,26 +145,36 @@
     (hash-put! table key new-val)
     new-val))
 
-;; Improved hash-merge variant which accepts an optional keyword argument indicating whether the base
-;; table should have its key/value bindings replaced by the other table's binding
-;; if same key exists in both base table and other table.
-;; If more than one other table is given after the base table and bindings for the same key exist
-;; in multiple other tables and the optional keyword argument is not #f then the rightmost table's
-;; binding takes precedence.
-;; Replaces the existing hash-merge binding in Gerbil Prelude.
+;; Merge hash tables together and produce a new hash table. If same key exists in both base table
+;; and rest of other tables then the key/value binding of the base table takes precedence.
 ;; : Table <- Table (Optional-Keyword Bool) Table ...
-(def (hash-merge base-table other-table-takes-precedence?: (other-table-takes-precedence? #f) . rest)
-  (foldl (lambda (tab r) (table-merge r tab other-table-takes-precedence?))
+(def (hash-prefer-left base-table . rest)
+  (foldl (lambda (tab r) (table-merge r tab))
          base-table rest))
 
-;; Improved hash-merge! variant which accepts an optional keyword argument indicating whether the base
-;; table should have its key/value bindings replaced by the other table's binding
-;; if same key exists in both base table and other table.
-;; If more than one other table is given after the base table and bindings for the same key exist
-;; in multiple other tables and the optional keyword argument is not #f then the rightmost table's
-;; binding takes precedence.
-;; Replaces the existing hash-merge! binding in Gerbil Prelude.
+;; Merge hash tables together and update the base table's bindings. If same key exists in both base
+;; table and rest of other tables then the key/value binding of the base table takes precedence.
 ;; : Table <- Table (Optional-Keyword Bool) Table ...
-(def (hash-merge! base-table other-table-takes-precedence?: (other-table-takes-precedence? #f) . rest)
-  (foldl (lambda (tab r) (table-merge! r tab other-table-takes-precedence?))
+(def (hash-prefer-left! base-table . rest)
+  (foldl (lambda (tab r) (table-merge! r tab))
          base-table rest))
+
+;; Merge hash tables together and produce a new hash table. If same key exists in both base table
+;; and rest of other tables then the key/value binding of the other tables takes precedence.
+;; If more than one other table is given after the base table and bindings for the same key exist
+;; in multiple other tables then the rightmost table's binding takes precedence.
+;; : Table <- Table (Optional-Keyword Bool) Table ...
+(def (hash-prefer-right base-table . rest)
+  (foldl (lambda (tab r) (table-merge r tab #t))
+         base-table rest))
+
+;; Merge hash tables together and update the base table's bindings. If same key exists in both base
+;; table and rest of other tables then the key/value binding of the other tables takes precedence.
+;; If more than one other table is given after the base table and bindings for the same key exist
+;; in multiple other tables then the rightmost table's binding takes precedence.
+;; : Table <- Table (Optional-Keyword Bool) Table ...
+(def (hash-prefer-right! base-table . rest)
+  (foldl (lambda (tab r) (table-merge! r tab #t))
+         base-table rest))
+
+

--- a/utils/hash.ss
+++ b/utils/hash.ss
@@ -12,11 +12,14 @@
   hash-ensure-removed!
   hash-ensure-modify
   hash-empty?
+  hash-merge
+  hash-merge!
   )
 
 (import
   :std/iter
-  :clan/utils/base)
+  :clan/utils/base
+  :gerbil/gambit/hash)
 
 (def (hash-empty? h)
   (zero? (hash-length h)))
@@ -139,3 +142,27 @@
          (new-val (function val)))
     (hash-put! table key new-val)
     new-val))
+
+;; Improved hash-merge variant which accepts an optional keyword argument indicating whether the base
+;; table should have its key/value bindings replaced by the other table's binding
+;; if same key exists in both base table and other table.
+;; If more than one other table is given after the base table and bindings for the same key exist
+;; in multiple other tables and the optional keyword argument is not #f then the rightmost table's
+;; binding takes precedence.
+;; Replaces the existing hash-merge binding in Gerbil Prelude.
+;; : Table <- Table (Optional-Keyword Bool) Table ...
+(def (hash-merge base-table other-table-takes-precedence?: (other-table-takes-precedence? #f) . rest)
+  (foldl (lambda (tab r) (table-merge r tab other-table-takes-precedence?))
+         base-table rest))
+
+;; Improved hash-merge! variant which accepts an optional keyword argument indicating whether the base
+;; table should have its key/value bindings replaced by the other table's binding
+;; if same key exists in both base table and other table.
+;; If more than one other table is given after the base table and bindings for the same key exist
+;; in multiple other tables and the optional keyword argument is not #f then the rightmost table's
+;; binding takes precedence.
+;; Replaces the existing hash-merge! binding in Gerbil Prelude.
+;; : Table <- Table (Optional-Keyword Bool) Table ...
+(def (hash-merge! base-table other-table-takes-precedence?: (other-table-takes-precedence? #f) . rest)
+  (foldl (lambda (tab r) (table-merge! r tab other-table-takes-precedence?))
+         base-table rest))


### PR DESCRIPTION
…ound in Gerbil Prelude.

The new variants includes an optional keyword `other-table-takes-precedence?:` argument to specify
if the base table's key/value binding is replaced by any other table's binding if the key exists in
both base table and the other table.

If more than one table is given after the base table argument and multiple bindings for the same key
exist in multiple tables and `other-table-takes-precedence?:` is #t then the rightmost table's binding
takes precedence.

I've tested them on my system and they work as expected though I haven't added any test cases to the gerbil-utils' codebase.