### PR TITLE
add pure/dict with dicteq, assq, intdict, symdict

### DIFF
--- a/build.ss
+++ b/build.ss
@@ -12,4 +12,4 @@
         (and (equal? (path-extension filename) ".ss")
              (path-expand (path-strip-extension filename) dir)))
       (directory-files dir)))
-   ["utils" "net" "poo"]))
+   ["utils" "net" "poo" "pure/dict" "pure"]))

--- a/pure/dict.ss
+++ b/pure/dict.ss
@@ -1,0 +1,10 @@
+(export (import:
+         :clan/pure/dict/assq
+         :clan/pure/dict/dicteq
+         :clan/pure/dict/intdict
+         :clan/pure/dict/symdict))
+
+(import :clan/pure/dict/assq
+        :clan/pure/dict/dicteq
+        :clan/pure/dict/intdict
+        :clan/pure/dict/symdict)

--- a/pure/dict/assq.ss
+++ b/pure/dict/assq.ss
@@ -1,0 +1,62 @@
+(export assq-ref
+        assq-put
+        assq-update
+        assq-remove
+        assq-has-key?
+        assq-keys
+        assq-put/list
+        list->assq
+        assq=?)
+
+;; An [Assqof K V] is a [Listof [Cons K V]]
+;; where the keys should be compared by `eq?`,
+;; and there are no duplicate keys
+
+;; assq-ref : [Assqof K V] K -> V
+(def (assq-ref a k)
+  (def e (assq k a))
+  (if e (cdr e) (error 'assq-ref)))
+
+;; assq-put : [Assqof K V] K V -> [Assqof K V]
+;; do not introduce duplicate keys, if key exists remove old entry
+(def (assq-put a k v)
+  (def e (assq k a))
+  (cons (cons k v) (if e (remq e a) a)))
+
+;; assq-update : [Assqof K V] K [V -> V] V -> [Assqof K V]
+;; do not introduce duplicate keys, if key exists remove old entry
+(def (assq-update a k f v0)
+  (def e (assq k a))
+  (cond (e    (cons (cons k (f (cdr e))) (remq e a)))
+        (else (cons (cons k (f v0)) a))))
+
+;; assq-remove : [Assqof K V] K -> [Assqof K V]
+(def (assq-remove a k)
+  (def e (assq k a))
+  (if e (remq e a) a))
+
+;; assq-has-key? : [Assqof K V] K -> Bool
+(def (assq-has-key? a k)
+  (and (assq k a) #t))
+
+;; assq-keys : [Assqof K V] -> [Listof K]
+(def (assq-keys a) (map car a))
+
+;; assq-put/list : [Assqof K V] [Listof [Cons K V]] -> [Assqof K V]
+;; `a` has no duplicate keys, but `l` can
+(def (assq-put/list a l)
+  (cond ((null? l) a)
+        (else (assq-put/list (assq-put a (caar l) (cdar l)) (cdr l)))))
+
+;; list->assq : [Listof [Cons K V]] -> [Assqof K V]
+;; output has no duplicate keys
+(def (list->assq l) (assq-put/list [] l))
+
+;; assq=? : [Assqof Any Any] [Assqof Any Any] -> Bool
+;; can assume each has no duplicate keys, but possibly different order
+(def (assq=? a b (v=? equal?))
+  (and (= (length a) (length b))
+       (andmap (lambda (ae)
+                 (def be (assq (car ae) b))
+                 (and be (v=? (cdr ae) (cdr be))))
+               a)))

--- a/pure/dict/dicteq.ss
+++ b/pure/dict/dicteq.ss
@@ -1,0 +1,91 @@
+(export empty-dicteq
+        dicteq-empty?
+        dicteq-ref
+        dicteq-put
+        dicteq-update
+        dicteq-remove
+        dicteq-has-key?
+        dicteq-keys
+        dicteq-put/list
+        list->dicteq
+        dicteq->list
+        dicteq=?)
+
+(import :std/iter
+        :std/misc/rbtree
+        :std/srfi/1
+        :clan/pure/dict/assq
+        :clan/pure/dict/intdict)
+
+
+
+;; Functional Dictionaries mapping keys to values according to eq-ness
+
+;; An [Assqof K V] is a [Listof [Cons K V]]
+;; where the keys should be compared by `eq?`,
+;; and there are no duplicate keys
+
+;; A [DictEqof K V] is an [Intdictof [Assqof K V]]
+
+;; empty-dicteq : [DictEqof K V]
+(def empty-dicteq empty-intdict)
+
+;; dicteq-empty? : [DictEqof K V] -> Bool
+(def dicteq-empty? intdict-empty?)
+
+;; dicteq-ref : [DictEqof K V] K -> V
+(def (dicteq-ref d k)
+  (def a (intdict-ref d (eq?-hash k)))
+  (def e (assq k a))
+  (cond (e (cdr e))
+        (else (error 'dicteq-ref))))
+
+;; dicteq-put : [DictEqof K V] K V -> [DictEqof K V]
+(def (dicteq-put d k v)
+  (rbtree-update
+    d
+    (eq?-hash k)
+    (lambda (a) (assq-put a k v))
+    []))
+
+;; dicteq-update : [DictEqof K V] K [V -> V] V -> [DictEqof K V]
+(def (dicteq-update d k f v0)
+  (rbtree-update
+    d
+    (eq?-hash k)
+    (lambda (a) (assq-update a k f v0))
+    []))
+
+;; dicteq-remove : [DictEqof K V] K -> [DictEqof K V]
+(def (dicteq-remove d k)
+  (def kh (eq?-hash k))
+  (def a (assq-remove (intdict-ref d kh []) k))
+  (if (null? a) (intdict-remove d kh) (intdict-put d kh a)))
+
+;; dicteq-has-key? : [DictEqof K V] K -> Bool
+(def (dicteq-has-key? d k)
+  (assq-has-key? (intdict-ref d (eq?-hash k) []) k))
+
+;; dicteq-keys : [DictEqof K V] -> [Listof K]
+(def (dicteq-keys d)
+  (for/fold (l []) (a (in-rbtree-values d))
+    (append-reverse (assq-keys a) l)))
+
+;; dicteq-put/list : [DictEqof K V] [Listof [Cons K V]] -> [DictEqof K V]
+(def (dicteq-put/list d l)
+  (cond ((null? l) d)
+        (else (dicteq-put/list (dicteq-put d (caar l) (cdar l)) (cdr l)))))
+
+;; list->dicteq : [Listof [Cons K V]] -> [DictEqof K V]
+(def (list->dicteq l) (dicteq-put/list empty-dicteq l))
+
+;; dicteq->list : [DictEqof K V] -> [Listof [Cons K V]]
+(def (dicteq->list d)
+  (for/fold (l []) (vs (in-rbtree-values d))
+    (append-reverse vs l)))
+
+;; dicteq=? : [DictEqof Any Any] [DictEqof Any Any] -> Bool
+(def (dicteq=? a b (v=? equal?))
+  (intdict=? a b
+             (lambda (a1 b1)
+               (assq=? a1 b1 v=?))))

--- a/pure/dict/intdict.ss
+++ b/pure/dict/intdict.ss
@@ -1,0 +1,66 @@
+(export empty-intdict
+        intdict-empty?
+        intdict-ref
+        intdict-put
+        intdict-update
+        intdict-remove
+        intdict-has-key?
+        intdict-keys
+        intdict-put/list
+        list->intdict
+        intdict->list
+        intdict=?)
+
+(import :std/iter
+        :std/misc/rbtree)
+
+;; Functional Dictionaries mapping integer keys to values
+
+;; An [Intdictof V] is an [Rbtreeof Int V]
+
+;; empty-intdict : [Intdictof V]
+(def empty-intdict (make-rbtree -))
+
+;; intdict-empty? : [Intdictof V] -> Bool
+(def intdict-empty? rbtree-empty?)
+
+;; intdict-ref : [Intdictof V] Int -> V
+(def intdict-ref rbtree-ref)
+
+;; intdict-put : [Intdictof V] Int V -> [Intdictof V]
+(def intdict-put rbtree-put)
+
+;; intdict-update : [Intdictof V] Int [V -> V] V -> [Intdictof V]
+(def intdict-update rbtree-update)
+
+;; intdict-remove : [Intdictof V] Int -> [Intdictof V]
+(def intdict-remove rbtree-remove)
+
+;; intdict-has-key? : [Intdictof V] Int -> Bool
+(def (intdict-has-key? d k)
+  (def notfound (gensym 'notfound))
+  (not (eq? notfound (rbtree-ref d k notfound))))
+
+;; intdict-keys : [Intdictof V] -> [Listof Int]
+(def (intdict-keys d) (for/collect (k (in-rbtree-keys d)) k))
+
+;; intdict-put/list : [Intdictof V] [Listof [Cons Int V]] -> [Intdictof V]
+(def (intdict-put/list d l)
+  (cond ((null? l) d)
+        (else (intdict-put/list (intdict-put d (caar l) (cdar l)) (cdr l)))))
+
+;; list->intdict : [Listof [Cons Int V]] -> [Intdictof V]
+(def (list->intdict l) (intdict-put/list empty-intdict l))
+
+;; intdict->list : [Intdictof V] -> [Listof [Cons Int V]]
+(def intdict->list rbtree->list)
+
+;; intdict=? : [Intdictof Any] [Intdictof Any] -> Bool
+(def (intdict=? a b (v=? equal?))
+  (def aks (intdict-keys a))
+  (def bks (intdict-keys b))
+  (and (= (length aks) (length bks))
+       (andmap (lambda (k)
+                 (and (intdict-has-key? b k)
+                      (v=? (intdict-ref a k) (intdict-ref b k))))
+               aks)))

--- a/pure/dict/symdict.ss
+++ b/pure/dict/symdict.ss
@@ -38,6 +38,8 @@
 
 ;; symdict-has-key? : [Symdictof V] Symbol -> Bool
 (def (symdict-has-key? d k)
+  (unless (rbtree? d) (error 'symdict-has-key? "expected a symdict as 1st argument"))
+  (unless (symbol? k) (error 'symdict-has-key? "expected a symbol as 2nd argument"))
   (def notfound (gensym 'notfound))
   (not (eq? notfound (rbtree-ref d k notfound))))
 

--- a/pure/dict/symdict.ss
+++ b/pure/dict/symdict.ss
@@ -1,0 +1,66 @@
+(export empty-symdict
+        symdict-empty?
+        symdict-ref
+        symdict-put
+        symdict-update
+        symdict-remove
+        symdict-has-key?
+        symdict-keys
+        symdict-put/list
+        list->symdict
+        symdict->list
+        symdict=?)
+
+(import :std/iter
+        :std/misc/rbtree)
+
+;; Functional Dictionaries mapping Symbol keys to values
+
+;; An [Symdictof V] is an [Rbtreeof Symbol V]
+
+;; empty-symdict : [Symdictof V]
+(def empty-symdict (make-rbtree symbol-hash-cmp))
+
+;; symdict-empty? : [Symdictof V] -> Bool
+(def symdict-empty? rbtree-empty?)
+
+;; symdict-ref : [Symdictof V] Sym -> V
+(def symdict-ref rbtree-ref)
+
+;; symdict-put : [Symdictof V] Symbol V -> [Symdictof V]
+(def symdict-put rbtree-put)
+
+;; symdict-update : [Symdictof V] Symbol [V -> V] V -> [Symdictof V]
+(def symdict-update rbtree-update)
+
+;; symdict-remove : [Symdictof V] Symbol -> [Symdictof V]
+(def symdict-remove rbtree-remove)
+
+;; symdict-has-key? : [Symdictof V] Symbol -> Bool
+(def (symdict-has-key? d k)
+  (def notfound (gensym 'notfound))
+  (not (eq? notfound (rbtree-ref d k notfound))))
+
+;; symdict-keys : [Symdictof V] -> [Listof Symbol]
+(def (symdict-keys d) (for/collect (k (in-rbtree-keys d)) k))
+
+;; symdict-put/list : [Symdictof V] [Listof [Cons Symbol V]] -> [Symdictof V]
+(def (symdict-put/list d l)
+  (cond ((null? l) d)
+        (else (symdict-put/list (symdict-put d (caar l) (cdar l)) (cdr l)))))
+
+;; list->symdict : [Listof [Cons Symbol V]] -> [Symdictof V]
+(def (list->symdict l) (symdict-put/list empty-symdict l))
+
+;; symdict->list : [Symdictof V] -> [Listof [Cons Symbol V]]
+(def symdict->list rbtree->list)
+
+;; symdict=? : [Symdictof Any] [Symdictof Any] -> Bool
+(def (symdict=? a b (v=? equal?))
+  (def aks (symdict-keys a))
+  (def bks (symdict-keys b))
+  (and (= (length aks) (length bks))
+       (andmap (lambda (k)
+                 (and (symdict-has-key? b k)
+                      (v=? (symdict-ref a k) (symdict-ref b k))))
+               aks)))

--- a/pure/dict/tests/Makefile
+++ b/pure/dict/tests/Makefile
@@ -1,0 +1,3 @@
+
+test: *.ss
+	./run-unit-tests.ss

--- a/pure/dict/tests/all-tests.ss
+++ b/pure/dict/tests/all-tests.ss
@@ -1,0 +1,8 @@
+(export
+  unit-tests)
+
+(import
+  "assq-test.ss" "symdict-test.ss" "dicteq-test.ss")
+
+(def unit-tests
+  [assq-test symdict-test dicteq-test])

--- a/pure/dict/tests/assq-test.ss
+++ b/pure/dict/tests/assq-test.ss
@@ -1,0 +1,48 @@
+(export assq-test)
+
+(import :std/test
+        :clan/pure/dict/assq)
+
+(def assq-test
+  (test-suite "test suite for clan/pure/dict/assq"
+    (check-equal? (list->assq []) [])
+    (check-equal? (list->assq '((red . 5))) '((red . 5)))
+
+    (check-equal? (assq-ref '((red . 5) (blue . 4) (black . 1)) 'blue)
+                4)
+    (check-equal? (assq-ref '((red . 5) (blue . 4) (black . 1)) 'red)
+                5)
+    (check-equal? (assq-ref '((red . 5) (blue . 4) (black . 1)) 'black)
+                1)
+
+    (check-equal? (assq-put [] 'red [255 0 0])
+                '((red . (255 0 0))))
+    (check-equal? (assq-put (assq-put [] 'red [255 0 0]) 'blue [0 255 0])
+                '((blue . (0 255 0)) (red . (255 0 0))))
+    (check-equal? (assq-put (assq-put [] 'blue [0 255 0]) 'red [255 0 0])
+                '((red . (255 0 0)) (blue . (0 255 0))))
+
+    (check-equal? (assq-update '((a . 10) (b . 20) (c . 30)) 'b 1+ 0)
+                '((b . 21) (a . 10) (c . 30)))
+    (check-equal? (assq-update '((a . 10) (b . 20) (c . 30)) 'd 1+ 0)
+                '((d . 1) (a . 10) (b . 20) (c . 30)))
+
+    (check-equal? (assq-remove '((a . 10) (b . 20) (c . 30)) 'b)
+                '((a . 10) (c . 30)))
+    (check-equal? (assq-remove '((a . 10) (b . 20) (c . 30)) 'd)
+                '((a . 10) (b . 20) (c . 30)))
+
+    (check-equal? (assq-has-key? '((a . 10) (b . 20) (c . 30)) 'a) #t)
+    (check-equal? (assq-has-key? '((a . 10) (b . 20) (c . 30)) 'b) #t)
+    (check-equal? (assq-has-key? '((a . 10) (b . 20) (c . 30)) 'c) #t)
+    (check-equal? (assq-has-key? '((a . 10) (b . 20) (c . 30)) 'd) #f)
+
+    (check-equal? (assq-keys '((red . 5) (blue . 4) (black . 1)))
+                ['red 'blue 'black])
+
+    (check assq=?
+        '((blue . (0 255 0)) (red . (255 0 0)))
+        '((red . (255 0 0)) (blue . (0 255 0))))
+    (check assq=?
+        (list->assq '((a . 1) (b . 2) (c . 3)))
+        '((a . 1) (b . 2) (c . 3)))))

--- a/pure/dict/tests/dicteq-test.ss
+++ b/pure/dict/tests/dicteq-test.ss
@@ -1,0 +1,64 @@
+(export dicteq-test)
+
+(import :std/test
+        :clan/pure/dict/dicteq
+        :clan/pure/dict/assq)
+
+(def dicteq-test
+  (test-suite "test suite for clan/pure/dict/dicteq"
+    (check-equal? (list->dicteq []) empty-dicteq)
+    (check-equal? (dicteq->list empty-dicteq) [])
+    (check-equal? (dicteq-empty? empty-dicteq) #t)
+    (check-equal? (dicteq-empty? (list->dicteq '((red . 5)))) #f)
+    (check-equal? (dicteq->list (list->dicteq '((red . 5)))) '((red . 5)))
+
+    (check-equal? (dicteq-ref (list->dicteq '((red . 5) (blue . 4) (black . 1))) 'blue)
+                  4)
+    (check-equal? (dicteq-ref (list->dicteq '((red . 5) (blue . 4) (black . 1))) 'red)
+                  5)
+    (check-equal? (dicteq-ref (list->dicteq '((red . 5) (blue . 4) (black . 1))) 'black)
+                  1)
+
+    (check dicteq=?
+           (dicteq-put empty-dicteq 'red [255 0 0])
+           (list->dicteq '((red . (255 0 0)))))
+    (check dicteq=?
+           (dicteq-put (dicteq-put empty-dicteq 'red [255 0 0]) 'blue [0 255 0])
+           (list->dicteq '((red . (255 0 0)) (blue . (0 255 0)))))
+    (check dicteq=?
+           (dicteq-put (dicteq-put empty-dicteq 'blue [0 255 0]) 'red [255 0 0])
+           (list->dicteq '((red . (255 0 0)) (blue . (0 255 0)))))
+
+    (check dicteq=?
+           (dicteq-update (list->dicteq '((a . 10) (b . 20) (c . 30))) 'b 1+ 0)
+           (list->dicteq '((b . 21) (a . 10) (c . 30))))
+    (check dicteq=?
+           (dicteq-update (list->dicteq '((a . 10) (b . 20) (c . 30))) 'd 1+ 0)
+           (list->dicteq '((d . 1) (a . 10) (b . 20) (c . 30))))
+
+    (check dicteq=?
+           (dicteq-remove (list->dicteq '((a . 10) (b . 20) (c . 30))) 'b)
+           (list->dicteq '((a . 10) (c . 30))))
+    (check dicteq=?
+           (dicteq-remove (list->dicteq '((a . 10) (b . 20) (c . 30))) 'd)
+           (list->dicteq '((a . 10) (b . 20) (c . 30))))
+
+    (check-equal? (dicteq-has-key? (list->dicteq '((a . 10) (b . 20) (c . 30))) 'a) #t)
+    (check-equal? (dicteq-has-key? (list->dicteq '((a . 10) (b . 20) (c . 30))) 'b) #t)
+    (check-equal? (dicteq-has-key? (list->dicteq '((a . 10) (b . 20) (c . 30))) 'c) #t)
+    (check-equal? (dicteq-has-key? (list->dicteq '((a . 10) (b . 20) (c . 30))) 'd) #f)
+
+    (def (list-set=? as bs)
+      (and (andmap (lambda (a) (member a bs)) as)
+           (andmap (lambda (b) (member b as)) bs)))
+
+    (check list-set=?
+           (dicteq-keys (list->dicteq '((red . 5) (blue . 4) (black . 1))))
+           ['red 'blue 'black])
+
+    (check dicteq=?
+           (list->dicteq '((blue . (0 255 0)) (red . (255 0 0))))
+           (list->dicteq '((red . (255 0 0)) (blue . (0 255 0)))))
+    (check assq=?
+           (dicteq->list (list->dicteq '((a . 1) (b . 2) (c . 3))))
+           '((a . 1) (b . 2) (c . 3)))))

--- a/pure/dict/tests/run-unit-tests.ss
+++ b/pure/dict/tests/run-unit-tests.ss
@@ -1,0 +1,12 @@
+#!/usr/bin/env gxi
+
+(import
+  :std/test
+  "all-tests.ss")
+
+(apply run-tests! unit-tests)
+(test-report-summary!)
+
+(case (test-result)
+  ((OK) (exit 0))
+  (else (exit 1)))

--- a/pure/dict/tests/symdict-test.ss
+++ b/pure/dict/tests/symdict-test.ss
@@ -1,0 +1,65 @@
+(export symdict-test)
+
+(import :std/test
+        :clan/pure/dict/symdict
+        :clan/pure/dict/assq)
+
+(def symdict-test
+  (test-suite "test suite for clan/pure/dict/symdict"
+    (check-equal? (list->symdict []) empty-symdict)
+    (check-equal? (symdict->list empty-symdict) [])
+    (check-equal? (symdict-empty? empty-symdict) #t)
+    (check-equal? (symdict-empty? (list->symdict '((red . 5)))) #f)
+    (check-equal? (symdict->list (list->symdict '((red . 5)))) '((red . 5)))
+
+    (check-equal? (symdict-ref (list->symdict '((red . 5) (blue . 4) (black . 1))) 'blue)
+                  4)
+    (check-equal? (symdict-ref (list->symdict '((red . 5) (blue . 4) (black . 1))) 'red)
+                  5)
+    (check-equal? (symdict-ref (list->symdict '((red . 5) (blue . 4) (black . 1))) 'black)
+                  1)
+
+    (check symdict=?
+           (symdict-put empty-symdict 'red [255 0 0])
+           (list->symdict '((red . (255 0 0)))))
+    (check symdict=?
+           (symdict-put (symdict-put empty-symdict 'red [255 0 0]) 'blue [0 255 0])
+           (list->symdict '((blue . (0 255 0)) (red . (255 0 0)))))
+    (check symdict=?
+           (symdict-put (symdict-put empty-symdict 'blue [0 255 0]) 'red [255 0 0])
+           (list->symdict '((red . (255 0 0)) (blue . (0 255 0)))))
+
+    (check symdict=?
+           (symdict-update (list->symdict '((a . 10) (b . 20) (c . 30))) 'b 1+ 0)
+           (list->symdict '((b . 21) (a . 10) (c . 30))))
+    (check symdict=?
+           (symdict-update (list->symdict '((a . 10) (b . 20) (c . 30))) 'd 1+ 0)
+           (list->symdict '((d . 1) (a . 10) (b . 20) (c . 30))))
+
+    (check symdict=?
+           (symdict-remove (list->symdict '((a . 10) (b . 20) (c . 30))) 'b)
+           (list->symdict '((a . 10) (c . 30))))
+    (check symdict=?
+           (symdict-remove (list->symdict '((a . 10) (b . 20) (c . 30))) 'd)
+           (list->symdict '((a . 10) (b . 20) (c . 30))))
+
+    (check-equal? (symdict-has-key? (list->symdict '((a . 10) (b . 20) (c . 30))) 'a) #t)
+    (check-equal? (symdict-has-key? (list->symdict '((a . 10) (b . 20) (c . 30))) 'b) #t)
+    (check-equal? (symdict-has-key? (list->symdict '((a . 10) (b . 20) (c . 30))) 'c) #t)
+    (check-equal? (symdict-has-key? (list->symdict '((a . 10) (b . 20) (c . 30))) 'd) #f)
+
+    (def (list-set=? as bs)
+      (and (= (length as) (length bs))
+           (andmap (lambda (a) (member a bs)) as)
+           (andmap (lambda (b) (member b as)) bs)))
+
+    (check list-set=?
+           (symdict-keys (list->symdict '((red . 5) (blue . 4) (black . 1))))
+           ['red 'blue 'black])
+
+    (check symdict=?
+           (list->symdict '((blue . (0 255 0)) (red . (255 0 0))))
+           (list->symdict '((red . (255 0 0)) (blue . (0 255 0)))))
+    (check assq=?
+           (symdict->list (list->symdict '((a . 1) (b . 2) (c . 3))))
+           '((a . 1) (b . 2) (c . 3)))))


### PR DESCRIPTION
This adds 5 modules:
 - `:clan/pure/dict` reprovide other 4 inner modules
 - `:clan/pure/dict/dicteq` dictionaries based on rbtrees with keys distinguished by eq?
 - `:clan/pure/dict/assq` association lists based on eq?
 - `:clan/pure/dict/intdict` dictionaries based on rbtrees with only integer keys
 - `:clan/pure/dict/symdict` dictionaries based on rbtrees with symbol keys based on symbol hash
