### PR TITLE
wrap dicts in structs

### DIFF
--- a/pure/dict/dicteq-unwrapped.ss
+++ b/pure/dict/dicteq-unwrapped.ss
@@ -1,0 +1,91 @@
+(export empty-dicteq
+        dicteq-empty?
+        dicteq-ref
+        dicteq-put
+        dicteq-update
+        dicteq-remove
+        dicteq-has-key?
+        dicteq-keys
+        dicteq-put/list
+        list->dicteq
+        dicteq->list
+        dicteq=?)
+
+(import :std/iter
+        :std/misc/rbtree
+        :std/srfi/1
+        :clan/pure/dict/assq
+        :clan/pure/dict/intdict-unwrapped)
+
+
+
+;; Functional Dictionaries mapping keys to values according to eq-ness
+
+;; An [Assqof K V] is a [Listof [Cons K V]]
+;; where the keys should be compared by `eq?`,
+;; and there are no duplicate keys
+
+;; A [DictEqof K V] is an [Intdictof [Assqof K V]]
+
+;; empty-dicteq : [DictEqof K V]
+(def empty-dicteq empty-intdict)
+
+;; dicteq-empty? : [DictEqof K V] -> Bool
+(def dicteq-empty? intdict-empty?)
+
+;; dicteq-ref : [DictEqof K V] K -> V
+(def (dicteq-ref d k)
+  (def a (intdict-ref d (eq?-hash k)))
+  (def e (assq k a))
+  (cond (e (cdr e))
+        (else (error 'dicteq-ref))))
+
+;; dicteq-put : [DictEqof K V] K V -> [DictEqof K V]
+(def (dicteq-put d k v)
+  (rbtree-update
+    d
+    (eq?-hash k)
+    (lambda (a) (assq-put a k v))
+    []))
+
+;; dicteq-update : [DictEqof K V] K [V -> V] V -> [DictEqof K V]
+(def (dicteq-update d k f v0)
+  (rbtree-update
+    d
+    (eq?-hash k)
+    (lambda (a) (assq-update a k f v0))
+    []))
+
+;; dicteq-remove : [DictEqof K V] K -> [DictEqof K V]
+(def (dicteq-remove d k)
+  (def kh (eq?-hash k))
+  (def a (assq-remove (intdict-ref d kh []) k))
+  (if (null? a) (intdict-remove d kh) (intdict-put d kh a)))
+
+;; dicteq-has-key? : [DictEqof K V] K -> Bool
+(def (dicteq-has-key? d k)
+  (assq-has-key? (intdict-ref d (eq?-hash k) []) k))
+
+;; dicteq-keys : [DictEqof K V] -> [Listof K]
+(def (dicteq-keys d)
+  (for/fold (l []) (a (in-rbtree-values d))
+    (append-reverse (assq-keys a) l)))
+
+;; dicteq-put/list : [DictEqof K V] [Listof [Cons K V]] -> [DictEqof K V]
+(def (dicteq-put/list d l)
+  (cond ((null? l) d)
+        (else (dicteq-put/list (dicteq-put d (caar l) (cdar l)) (cdr l)))))
+
+;; list->dicteq : [Listof [Cons K V]] -> [DictEqof K V]
+(def (list->dicteq l) (dicteq-put/list empty-dicteq l))
+
+;; dicteq->list : [DictEqof K V] -> [Listof [Cons K V]]
+(def (dicteq->list d)
+  (for/fold (l []) (vs (in-rbtree-values d))
+    (append-reverse vs l)))
+
+;; dicteq=? : [DictEqof Any Any] [DictEqof Any Any] -> Bool
+(def (dicteq=? a b (v=? equal?))
+  (intdict=? a b
+             (lambda (a1 b1)
+               (assq=? a1 b1 v=?))))

--- a/pure/dict/dicteq.ss
+++ b/pure/dict/dicteq.ss
@@ -9,83 +9,70 @@
         dicteq-put/list
         list->dicteq
         dicteq->list
-        dicteq=?)
+        dicteq=?
+        (rename: *dicteq dicteq))
 
 (import :std/iter
-        :std/misc/rbtree
-        :std/srfi/1
-        :clan/pure/dict/assq
-        :clan/pure/dict/intdict)
+        :std/misc/repr
+        (prefix-in :clan/pure/dict/dicteq-unwrapped bare-))
 
-
-
-;; Functional Dictionaries mapping keys to values according to eq-ness
-
-;; An [Assqof K V] is a [Listof [Cons K V]]
-;; where the keys should be compared by `eq?`,
-;; and there are no duplicate keys
-
-;; A [DictEqof K V] is an [Intdictof [Assqof K V]]
+(defstruct dicteq (unwrapped))
 
 ;; empty-dicteq : [DictEqof K V]
-(def empty-dicteq empty-intdict)
+(def empty-dicteq (dicteq bare-empty-dicteq))
 
 ;; dicteq-empty? : [DictEqof K V] -> Bool
-(def dicteq-empty? intdict-empty?)
+(def (dicteq-empty? d) (bare-dicteq-empty? (dicteq-unwrapped d)))
 
 ;; dicteq-ref : [DictEqof K V] K -> V
-(def (dicteq-ref d k)
-  (def a (intdict-ref d (eq?-hash k)))
-  (def e (assq k a))
-  (cond (e (cdr e))
-        (else (error 'dicteq-ref))))
+(def (dicteq-ref d k) (bare-dicteq-ref (dicteq-unwrapped d) k))
 
 ;; dicteq-put : [DictEqof K V] K V -> [DictEqof K V]
-(def (dicteq-put d k v)
-  (rbtree-update
-    d
-    (eq?-hash k)
-    (lambda (a) (assq-put a k v))
-    []))
+(def (dicteq-put d k v) (dicteq (bare-dicteq-put (dicteq-unwrapped d) k v)))
 
 ;; dicteq-update : [DictEqof K V] K [V -> V] V -> [DictEqof K V]
-(def (dicteq-update d k f v0)
-  (rbtree-update
-    d
-    (eq?-hash k)
-    (lambda (a) (assq-update a k f v0))
-    []))
+(def (dicteq-update d k f v0) (dicteq (bare-dicteq-update (dicteq-unwrapped d) k f v0)))
 
 ;; dicteq-remove : [DictEqof K V] K -> [DictEqof K V]
-(def (dicteq-remove d k)
-  (def kh (eq?-hash k))
-  (def a (assq-remove (intdict-ref d kh []) k))
-  (if (null? a) (intdict-remove d kh) (intdict-put d kh a)))
+(def (dicteq-remove d k) (dicteq (bare-dicteq-remove (dicteq-unwrapped d) k)))
 
 ;; dicteq-has-key? : [DictEqof K V] K -> Bool
-(def (dicteq-has-key? d k)
-  (assq-has-key? (intdict-ref d (eq?-hash k) []) k))
+(def (dicteq-has-key? d k) (bare-dicteq-has-key? (dicteq-unwrapped d) k))
 
 ;; dicteq-keys : [DictEqof K V] -> [Listof K]
-(def (dicteq-keys d)
-  (for/fold (l []) (a (in-rbtree-values d))
-    (append-reverse (assq-keys a) l)))
+(def (dicteq-keys d) (bare-dicteq-keys (dicteq-unwrapped d)))
 
 ;; dicteq-put/list : [DictEqof K V] [Listof [Cons K V]] -> [DictEqof K V]
-(def (dicteq-put/list d l)
-  (cond ((null? l) d)
-        (else (dicteq-put/list (dicteq-put d (caar l) (cdar l)) (cdr l)))))
+(def (dicteq-put/list d l) (dicteq (bare-dicteq-put/list (dicteq-unwrapped d) l)))
 
 ;; list->dicteq : [Listof [Cons K V]] -> [DictEqof K V]
-(def (list->dicteq l) (dicteq-put/list empty-dicteq l))
+(def (list->dicteq l) (dicteq (bare-list->dicteq l)))
 
 ;; dicteq->list : [DictEqof K V] -> [Listof [Cons K V]]
-(def (dicteq->list d)
-  (for/fold (l []) (vs (in-rbtree-values d))
-    (append-reverse vs l)))
+(def (dicteq->list d) (bare-dicteq->list (dicteq-unwrapped d)))
 
 ;; dicteq=? : [DictEqof Any Any] [DictEqof Any Any] -> Bool
 (def (dicteq=? a b (v=? equal?))
-  (intdict=? a b
-             (lambda (a1 b1)
-               (assq=? a1 b1 v=?))))
+  (bare-dicteq=? (dicteq-unwrapped a) (dicteq-unwrapped b) v=?))
+
+;; (*dicteq (k v) ...)
+;; export-renamed to (dicteq (k v) ...)
+(defsyntax *dicteq
+  (lambda (stx)
+    (syntax-case stx ()
+      ((_ (k v) ...)
+       #'(list->dicteq [(cons k v) ...])))))
+
+;; controls print-representation, pr, prn, and repr
+;; prints as (dicteq (k v) ...)
+(defmethod {:pr dicteq}
+  (lambda (self port options)
+    (with ((dicteq bare) self)
+      (display "(dicteq" port)
+      (for ((k (bare-dicteq-keys bare)))
+        (display " (" port)
+        (pr k port options)
+        (display " " port)
+        (pr (bare-dicteq-ref bare k) port options)
+        (display ")" port))
+      (display ")" port))))

--- a/pure/dict/intdict-unwrapped.ss
+++ b/pure/dict/intdict-unwrapped.ss
@@ -1,0 +1,66 @@
+(export empty-intdict
+        intdict-empty?
+        intdict-ref
+        intdict-put
+        intdict-update
+        intdict-remove
+        intdict-has-key?
+        intdict-keys
+        intdict-put/list
+        list->intdict
+        intdict->list
+        intdict=?)
+
+(import :std/iter
+        :std/misc/rbtree)
+
+;; Functional Dictionaries mapping integer keys to values
+
+;; An [Intdictof V] is an [Rbtreeof Int V]
+
+;; empty-intdict : [Intdictof V]
+(def empty-intdict (make-rbtree -))
+
+;; intdict-empty? : [Intdictof V] -> Bool
+(def intdict-empty? rbtree-empty?)
+
+;; intdict-ref : [Intdictof V] Int -> V
+(def intdict-ref rbtree-ref)
+
+;; intdict-put : [Intdictof V] Int V -> [Intdictof V]
+(def intdict-put rbtree-put)
+
+;; intdict-update : [Intdictof V] Int [V -> V] V -> [Intdictof V]
+(def intdict-update rbtree-update)
+
+;; intdict-remove : [Intdictof V] Int -> [Intdictof V]
+(def intdict-remove rbtree-remove)
+
+;; intdict-has-key? : [Intdictof V] Int -> Bool
+(def (intdict-has-key? d k)
+  (def notfound (gensym 'notfound))
+  (not (eq? notfound (rbtree-ref d k notfound))))
+
+;; intdict-keys : [Intdictof V] -> [Listof Int]
+(def (intdict-keys d) (for/collect (k (in-rbtree-keys d)) k))
+
+;; intdict-put/list : [Intdictof V] [Listof [Cons Int V]] -> [Intdictof V]
+(def (intdict-put/list d l)
+  (cond ((null? l) d)
+        (else (intdict-put/list (intdict-put d (caar l) (cdar l)) (cdr l)))))
+
+;; list->intdict : [Listof [Cons Int V]] -> [Intdictof V]
+(def (list->intdict l) (intdict-put/list empty-intdict l))
+
+;; intdict->list : [Intdictof V] -> [Listof [Cons Int V]]
+(def intdict->list rbtree->list)
+
+;; intdict=? : [Intdictof Any] [Intdictof Any] -> Bool
+(def (intdict=? a b (v=? equal?))
+  (def aks (intdict-keys a))
+  (def bks (intdict-keys b))
+  (and (= (length aks) (length bks))
+       (andmap (lambda (k)
+                 (and (intdict-has-key? b k)
+                      (v=? (intdict-ref a k) (intdict-ref b k))))
+               aks)))

--- a/pure/dict/intdict.ss
+++ b/pure/dict/intdict.ss
@@ -9,58 +9,70 @@
         intdict-put/list
         list->intdict
         intdict->list
-        intdict=?)
+        intdict=?
+        (rename: *intdict intdict))
 
 (import :std/iter
-        :std/misc/rbtree)
+        :std/misc/repr
+        (prefix-in :clan/pure/dict/intdict-unwrapped bare-))
 
-;; Functional Dictionaries mapping integer keys to values
-
-;; An [Intdictof V] is an [Rbtreeof Int V]
+(defstruct intdict (unwrapped))
 
 ;; empty-intdict : [Intdictof V]
-(def empty-intdict (make-rbtree -))
+(def empty-intdict (intdict bare-empty-intdict))
 
 ;; intdict-empty? : [Intdictof V] -> Bool
-(def intdict-empty? rbtree-empty?)
+(def (intdict-empty? d) (bare-intdict-empty? (intdict-unwrapped d)))
 
 ;; intdict-ref : [Intdictof V] Int -> V
-(def intdict-ref rbtree-ref)
+(def (intdict-ref d k) (bare-intdict-ref (intdict-unwrapped d) k))
 
 ;; intdict-put : [Intdictof V] Int V -> [Intdictof V]
-(def intdict-put rbtree-put)
+(def (intdict-put d k v) (intdict (bare-intdict-put (intdict-unwrapped d) k v)))
 
 ;; intdict-update : [Intdictof V] Int [V -> V] V -> [Intdictof V]
-(def intdict-update rbtree-update)
+(def (intdict-update d k f v0) (intdict (bare-intdict-update (intdict-unwrapped d) k f v0)))
 
 ;; intdict-remove : [Intdictof V] Int -> [Intdictof V]
-(def intdict-remove rbtree-remove)
+(def (intdict-remove d k) (intdict (bare-intdict-remove (intdict-unwrapped d) k)))
 
 ;; intdict-has-key? : [Intdictof V] Int -> Bool
-(def (intdict-has-key? d k)
-  (def notfound (gensym 'notfound))
-  (not (eq? notfound (rbtree-ref d k notfound))))
+(def (intdict-has-key? d k) (bare-intdict-has-key? (intdict-unwrapped d) k))
 
 ;; intdict-keys : [Intdictof V] -> [Listof Int]
-(def (intdict-keys d) (for/collect (k (in-rbtree-keys d)) k))
+(def (intdict-keys d) (bare-intdict-keys (intdict-unwrapped d)))
 
 ;; intdict-put/list : [Intdictof V] [Listof [Cons Int V]] -> [Intdictof V]
-(def (intdict-put/list d l)
-  (cond ((null? l) d)
-        (else (intdict-put/list (intdict-put d (caar l) (cdar l)) (cdr l)))))
+(def (intdict-put/list d l) (intdict (bare-intdict-put/list (intdict-unwrapped d) l)))
 
 ;; list->intdict : [Listof [Cons Int V]] -> [Intdictof V]
-(def (list->intdict l) (intdict-put/list empty-intdict l))
+(def (list->intdict l) (intdict (bare-list->intdict l)))
 
 ;; intdict->list : [Intdictof V] -> [Listof [Cons Int V]]
-(def intdict->list rbtree->list)
+(def (intdict->list d) (bare-intdict->list (intdict-unwrapped d)))
 
 ;; intdict=? : [Intdictof Any] [Intdictof Any] -> Bool
 (def (intdict=? a b (v=? equal?))
-  (def aks (intdict-keys a))
-  (def bks (intdict-keys b))
-  (and (= (length aks) (length bks))
-       (andmap (lambda (k)
-                 (and (intdict-has-key? b k)
-                      (v=? (intdict-ref a k) (intdict-ref b k))))
-               aks)))
+  (bare-intdict=? (intdict-unwrapped a) (intdict-unwrapped b) v=?))
+
+;; (*intdict (k v) ...)
+;; export-renamed to (intdict (k v) ...)
+(defsyntax *intdict
+  (lambda (stx)
+    (syntax-case stx ()
+      ((_ (k v) ...)
+       #'(list->intdict [(cons k v) ...])))))
+
+;; controls print-representation, pr, prn, and repr
+;; prints as (intdict (k v) ...)
+(defmethod {:pr intdict}
+  (lambda (self port options)
+    (with ((intdict bare) self)
+      (display "(intdict" port)
+      (for ((k (bare-intdict-keys bare)))
+        (display " (" port)
+        (pr k port options)
+        (display " " port)
+        (pr (bare-intdict-ref bare k) port options)
+        (display ")" port))
+      (display ")" port))))

--- a/pure/dict/symdict-unwrapped.ss
+++ b/pure/dict/symdict-unwrapped.ss
@@ -1,0 +1,68 @@
+(export empty-symdict
+        symdict-empty?
+        symdict-ref
+        symdict-put
+        symdict-update
+        symdict-remove
+        symdict-has-key?
+        symdict-keys
+        symdict-put/list
+        list->symdict
+        symdict->list
+        symdict=?)
+
+(import :std/iter
+        :std/misc/rbtree)
+
+;; Functional Dictionaries mapping Symbol keys to values
+
+;; An [Symdictof V] is an [Rbtreeof Symbol V]
+
+;; empty-symdict : [Symdictof V]
+(def empty-symdict (make-rbtree symbol-hash-cmp))
+
+;; symdict-empty? : [Symdictof V] -> Bool
+(def symdict-empty? rbtree-empty?)
+
+;; symdict-ref : [Symdictof V] Sym -> V
+(def symdict-ref rbtree-ref)
+
+;; symdict-put : [Symdictof V] Symbol V -> [Symdictof V]
+(def symdict-put rbtree-put)
+
+;; symdict-update : [Symdictof V] Symbol [V -> V] V -> [Symdictof V]
+(def symdict-update rbtree-update)
+
+;; symdict-remove : [Symdictof V] Symbol -> [Symdictof V]
+(def symdict-remove rbtree-remove)
+
+;; symdict-has-key? : [Symdictof V] Symbol -> Bool
+(def (symdict-has-key? d k)
+  (unless (rbtree? d) (error 'symdict-has-key? "expected a symdict as 1st argument"))
+  (unless (symbol? k) (error 'symdict-has-key? "expected a symbol as 2nd argument"))
+  (def notfound (gensym 'notfound))
+  (not (eq? notfound (rbtree-ref d k notfound))))
+
+;; symdict-keys : [Symdictof V] -> [Listof Symbol]
+(def (symdict-keys d) (for/collect (k (in-rbtree-keys d)) k))
+
+;; symdict-put/list : [Symdictof V] [Listof [Cons Symbol V]] -> [Symdictof V]
+(def (symdict-put/list d l)
+  (cond ((null? l) d)
+        (else (symdict-put/list (symdict-put d (caar l) (cdar l)) (cdr l)))))
+
+;; list->symdict : [Listof [Cons Symbol V]] -> [Symdictof V]
+(def (list->symdict l) (symdict-put/list empty-symdict l))
+
+;; symdict->list : [Symdictof V] -> [Listof [Cons Symbol V]]
+(def symdict->list rbtree->list)
+
+;; symdict=? : [Symdictof Any] [Symdictof Any] -> Bool
+(def (symdict=? a b (v=? equal?))
+  (def aks (symdict-keys a))
+  (def bks (symdict-keys b))
+  (and (= (length aks) (length bks))
+       (andmap (lambda (k)
+                 (and (symdict-has-key? b k)
+                      (v=? (symdict-ref a k) (symdict-ref b k))))
+               aks)))

--- a/pure/dict/symdict.ss
+++ b/pure/dict/symdict.ss
@@ -9,60 +9,70 @@
         symdict-put/list
         list->symdict
         symdict->list
-        symdict=?)
+        symdict=?
+        (rename: *symdict symdict))
 
 (import :std/iter
-        :std/misc/rbtree)
+        :std/misc/repr
+        (prefix-in :clan/pure/dict/symdict-unwrapped bare-))
 
-;; Functional Dictionaries mapping Symbol keys to values
-
-;; An [Symdictof V] is an [Rbtreeof Symbol V]
+(defstruct symdict (unwrapped))
 
 ;; empty-symdict : [Symdictof V]
-(def empty-symdict (make-rbtree symbol-hash-cmp))
+(def empty-symdict (symdict bare-empty-symdict))
 
 ;; symdict-empty? : [Symdictof V] -> Bool
-(def symdict-empty? rbtree-empty?)
+(def (symdict-empty? d) (bare-symdict-empty? (symdict-unwrapped d)))
 
-;; symdict-ref : [Symdictof V] Sym -> V
-(def symdict-ref rbtree-ref)
+;; symdict-ref : [Symdictof V] Symbol -> V
+(def (symdict-ref d k) (bare-symdict-ref (symdict-unwrapped d) k))
 
 ;; symdict-put : [Symdictof V] Symbol V -> [Symdictof V]
-(def symdict-put rbtree-put)
+(def (symdict-put d k v) (symdict (bare-symdict-put (symdict-unwrapped d) k v)))
 
 ;; symdict-update : [Symdictof V] Symbol [V -> V] V -> [Symdictof V]
-(def symdict-update rbtree-update)
+(def (symdict-update d k f v0) (symdict (bare-symdict-update (symdict-unwrapped d) k f v0)))
 
 ;; symdict-remove : [Symdictof V] Symbol -> [Symdictof V]
-(def symdict-remove rbtree-remove)
+(def (symdict-remove d k) (symdict (bare-symdict-remove (symdict-unwrapped d) k)))
 
 ;; symdict-has-key? : [Symdictof V] Symbol -> Bool
-(def (symdict-has-key? d k)
-  (unless (rbtree? d) (error 'symdict-has-key? "expected a symdict as 1st argument"))
-  (unless (symbol? k) (error 'symdict-has-key? "expected a symbol as 2nd argument"))
-  (def notfound (gensym 'notfound))
-  (not (eq? notfound (rbtree-ref d k notfound))))
+(def (symdict-has-key? d k) (bare-symdict-has-key? (symdict-unwrapped d) k))
 
 ;; symdict-keys : [Symdictof V] -> [Listof Symbol]
-(def (symdict-keys d) (for/collect (k (in-rbtree-keys d)) k))
+(def (symdict-keys d) (bare-symdict-keys (symdict-unwrapped d)))
 
 ;; symdict-put/list : [Symdictof V] [Listof [Cons Symbol V]] -> [Symdictof V]
-(def (symdict-put/list d l)
-  (cond ((null? l) d)
-        (else (symdict-put/list (symdict-put d (caar l) (cdar l)) (cdr l)))))
+(def (symdict-put/list d l) (symdict (bare-symdict-put/list (symdict-unwrapped d) l)))
 
 ;; list->symdict : [Listof [Cons Symbol V]] -> [Symdictof V]
-(def (list->symdict l) (symdict-put/list empty-symdict l))
+(def (list->symdict l) (symdict (bare-list->symdict l)))
 
 ;; symdict->list : [Symdictof V] -> [Listof [Cons Symbol V]]
-(def symdict->list rbtree->list)
+(def (symdict->list d) (bare-symdict->list (symdict-unwrapped d)))
 
 ;; symdict=? : [Symdictof Any] [Symdictof Any] -> Bool
 (def (symdict=? a b (v=? equal?))
-  (def aks (symdict-keys a))
-  (def bks (symdict-keys b))
-  (and (= (length aks) (length bks))
-       (andmap (lambda (k)
-                 (and (symdict-has-key? b k)
-                      (v=? (symdict-ref a k) (symdict-ref b k))))
-               aks)))
+  (bare-symdict=? (symdict-unwrapped a) (symdict-unwrapped b) v=?))
+
+;; (*symdict (k v) ...)
+;; export-renamed to (symdict (k v) ...)
+(defsyntax *symdict
+  (lambda (stx)
+    (syntax-case stx ()
+      ((_ (k v) ...)
+       #'(list->symdict [(cons k v) ...])))))
+
+;; controls print-representation, pr, prn, and repr
+;; prints as (symdict (k v) ...)
+(defmethod {:pr symdict}
+  (lambda (self port options)
+    (with ((symdict bare) self)
+      (display "(symdict" port)
+      (for ((k (bare-symdict-keys bare)))
+        (display " (" port)
+        (pr k port options)
+        (display " " port)
+        (pr (bare-symdict-ref bare k) port options)
+        (display ")" port))
+      (display ")" port))))

--- a/pure/dict/tests/dicteq-test.ss
+++ b/pure/dict/tests/dicteq-test.ss
@@ -6,7 +6,7 @@
 
 (def dicteq-test
   (test-suite "test suite for clan/pure/dict/dicteq"
-    (check-equal? (list->dicteq []) empty-dicteq)
+    (check dicteq=? (list->dicteq []) empty-dicteq)
     (check-equal? (dicteq->list empty-dicteq) [])
     (check-equal? (dicteq-empty? empty-dicteq) #t)
     (check-equal? (dicteq-empty? (list->dicteq '((red . 5)))) #f)

--- a/pure/dict/tests/symdict-test.ss
+++ b/pure/dict/tests/symdict-test.ss
@@ -6,7 +6,7 @@
 
 (def symdict-test
   (test-suite "test suite for clan/pure/dict/symdict"
-    (check-equal? (list->symdict []) empty-symdict)
+    (check symdict=? (list->symdict []) empty-symdict)
     (check-equal? (symdict->list empty-symdict) [])
     (check-equal? (symdict-empty? empty-symdict) #t)
     (check-equal? (symdict-empty? (list->symdict '((red . 5)))) #f)


### PR DESCRIPTION
* prevent mutation of underlying rbtrees
* print representation with :std/misc/repr

In the future: hook into a larger equality method, similar to Racket's gen:equal+hash