### PR TITLE
Pass ctx through helper macros to get original use-site scope

### DIFF
--- a/poo/brace.ss
+++ b/poo/brace.ss
@@ -7,4 +7,10 @@
   (prefix-in (only-in <MOP> @method) @)
   :clan/utils/base :clan/poo/poo)
 
-(defrule {args ...} (.o args ...))
+;; {args ...} -> (@method args ...) -> (.o args ...)
+;; except that for macro-scope it's -> (.o/derived #,stx args ...)
+(defsyntax @method
+  (lambda (stx)
+    (syntax-case stx ()
+      ((_ args ...)
+       (with-syntax ((ctx stx)) #'(.o/derived ctx args ...))))))


### PR DESCRIPTION
This PR changes `.o` and related forms to introduce identifier-versions of keywords like `a:` here, into the scope of the use-site `.o` identifier, or the use-site curly-braces `@method` identifier, instead of the definition-site of the macros within `poo.ss`. With these changes, these two examples pass:
```
> (import :clan/poo/poo :clan/poo/brace)
> (.get (.o a: 1 b: (+ a 1)) b)
2
> (.get {a: 1 b: (+ a 1)} b)
2
```
And they shadow existing uses of `a` in the outside scope:
```
> (let ((a 0)) (.get (.o a: 1 b: (+ a 1)) b))
2
> (let ((a 0)) (.get {a: 1 b: (+ a 1)} b))
2
```