### PR TITLE
Update uses of loggers

### DIFF
--- a/concurrency.ss
+++ b/concurrency.ss
@@ -1,13 +1,15 @@
 ;; -*- Gerbil -*-
 ;;;; Utilities for concurrency
 
-(export #t)
+(export (except-out #t errorf warnf infof debugf verbosef))
 
 (import
   :gerbil/gambit/bytes :gerbil/gambit/continuations :gerbil/gambit/random :gerbil/gambit/threads
   :std/actor :std/error :std/logger
   :std/misc/bytes :std/misc/completion :std/misc/list :std/misc/repr :std/sugar
   ./base ./error ./exception)
+
+(deflogger clan)
 
 ;;; Protocol for process shutdown: periodically check for the (shutdown?) flag,
 ;; so you can shutdown gracefully after having received a signal,
@@ -65,7 +67,7 @@
       (try
        (apply fun (append args more-args))
        (catch (e)
-         (log-error "unhandled exception" e))))))
+         (errorf "unhandled exception: ~a" e))))))
 
 
 ;;;; Sequentialize access to a (stateful) function

--- a/error.ss
+++ b/error.ss
@@ -2,15 +2,17 @@
 ;;;; General-purpose logging facility.
 ;; TODO: modify the interface to allow for actions on log rotation.
 
-(export #t)
+(export (except-out #t errorf warnf infof debugf verbosef))
 
 (import
   :gerbil/gambit/os
   :std/error :std/format :std/logger
   ./base)
 
+(deflogger clan)
+
 (def (warn-and-err format type . args)
-  (apply warning format type args)
+  (apply warnf format type args)
   (apply error type args))
 
 (def (abort! code msg . args)

--- a/logger.ss
+++ b/logger.ss
@@ -2,8 +2,7 @@
 ;;;; General-purpose logging facility.
 ;; TODO: modify the interface to allow for actions on log rotation.
 
-(export
-  #t)
+(export (except-out #t errorf warnf infof debugf verbosef))
 
 (import
   :gerbil/gambit/ports
@@ -11,6 +10,8 @@
   :std/srfi/13 :std/sugar :std/text/json
   ./base ./basic-parsers ./concurrency ./timestamp ./filesystem ./generator
   ./json ./list ./memo ./path ./path-config ./versioning)
+
+(deflogger clan)
 
 ;;; Logging text to a series of log files.
 ;; Start a new logger, with given name (optional) and a hook to call when switching files.
@@ -185,7 +186,7 @@
                   (syntax-rules ()
                     ((_ form) (delay (try form
                                           (catch (_)
-                                            (warning "Bad log entry ~a ~a" timestamp line)
+                                            (warnf "Bad log entry ~a ~a" timestamp line)
                                             (void))))))))
       (if (metadata-line? line)
         (metadata-hook timestamp (delay-warn (json<-string line)))

--- a/net/websocket.ss
+++ b/net/websocket.ss
@@ -1,12 +1,14 @@
 ;; -*- Gerbil -*-
 ;;;; Utilities for using websocket
 
-(export #t)
+(export (except-out #t errorf warnf infof debugf verbosef))
 
 (import
   :gerbil/gambit/threads
   :std/actor :std/error :std/logger :std/net/websocket :std/text/json :std/sugar
   ../base)
+
+(deflogger clan)
 
 (defproto websocket-client
   event: ;; asynchronous
@@ -19,7 +21,7 @@
            (ignore-errors
             (read-json (open-input-u8vector [char-encoding: 'UTF-8 init: bytes]))))
       (begin
-        (warning "websocket: server sent binary data (~s bytes)" (u8vector-length bytes))
+        (warnf "websocket: server sent binary data (~s bytes)" (u8vector-length bytes))
         (raise-io-error 'websocket "server sent binary data" bytes))))
 
 (def (websocket-encode-message-json msg)


### PR DESCRIPTION
After https://github.com/vyzo/gerbil/pull/638 the interface to `:std/logger` has changed. This PR updates it to use the new interface.