### PR TITLE
Suppress warnings in pkg-config-options

### DIFF
--- a/building.ss
+++ b/building.ss
@@ -73,7 +73,7 @@
   (def ($$ command)
     ($ (if nix-hack?
          (string-append "nix-shell '<nixpkgs>' -p pkg-config " (string-join nix-deps " ")
-                        " --run '" command "'")
+                        " --run '" command "' 2> /dev/null")
          command)))
   (when nix-hack? ($$ "echo ok")) ;; do a first run to ensure all dependencies are loaded
   (def ($pkg-config options)

--- a/bytes.ss
+++ b/bytes.ss
@@ -6,7 +6,7 @@
 
 (def (bytes-reverse b)
   (def l (bytes-length b))
-  (def r (make-bytes l))
+  (def r (make-bytes l 0))
   (for (i (in-range l))
     (bytes-set! r i (bytes-ref b (- l i 1))))
   r)

--- a/bytestring.ss
+++ b/bytestring.ss
@@ -43,10 +43,10 @@
 (def (for-byte-lines port f)
   (declare (fixnum) (not safe))
   (let/cc return
-    (def buf (make-bytes buffer-length))
+    (def buf (make-bytes buffer-length 0))
     (def other-bufs [])
     (def (newbuf)
-      (set! buf (make-bytes buffer-length)))
+      (set! buf (make-bytes buffer-length 0)))
     (def start 0)
     (def end 0)
     (def (fill-buf)
@@ -85,7 +85,7 @@
 
 (def (count-lines/port port)
   (declare (fixnum) (not safe))
-  (def buf (make-bytes buffer-length))
+  (def buf (make-bytes buffer-length 0))
   (let loop ((i 0))
     (def c (read-bytes buf port))
     (if (zero? c) i

--- a/io.ss
+++ b/io.ss
@@ -31,7 +31,7 @@
 ;; : <- UInt16 Out
 (def (marshal-uint16 n port)
   (assert! (<= 0 n 65535))
-  (def bytes (make-bytes 2))
+  (def bytes (make-bytes 2 0))
   (bytevector-u16-set! bytes 0 n big)
   (write-bytes bytes port))
 

--- a/number.ss
+++ b/number.ss
@@ -45,7 +45,7 @@
 (def (integer-length-in-bytes n) (n-bytes<-n-bits (integer-length n)))
 
 (def (bytes<-nat n (n-bytes (integer-length-in-bytes n)))
-  (def bytes (make-bytes n-bytes))
+  (def bytes (make-bytes n-bytes 0))
   (when (positive? n-bytes)
     (u8vector-uint-set! bytes 0 n big n-bytes))
   bytes)


### PR DESCRIPTION
This PR fixes the problem described below by suppressing the warnings that `nix-shell` prints to `stderr` inside `pkg-config-options`.

When I run `nix-shell` I get warnings `warning: ignoring untrusted substituter 'https://mukn.cachix.org'` and when `gerbil-crypto`'s build script uses the `nix-hack` in `$$` of `pkg-config-options`, this warning pollutes the values of `-ld-options` and `-cc-options`, resulting in these errors:
```
... build github.com/fare/gerbil-crypto
... compile keccak
gcc: error: warning:: No such file or directory
gcc: error: ignoring: No such file or directory
gcc: error: untrusted: No such file or directory
gcc: error: substituter: No such file or directory
gcc: error: https://mukn.cachix.org: No such file or directory
gcc: error: warning:: No such file or directory
gcc: error: ignoring: No such file or directory
gcc: error: untrusted: No such file or directory
gcc: error: substituter: No such file or directory
gcc: error: https://mukn.cachix.org: No such file or directory
*** ERROR IN ##main -- target compilation or link failed while compiling "~/.gerbil/lib/clan/crypto/keccak__0.scm"
```
Due to the `./build.ss spec` containing things like this:
```
$ ./build.ss spec
((gxc:
  "keccak"
  "-cc-options"
  "-I/Users/Alex/.gerbil/pkg/github.com/fare/gerbil-crypto"
  "-ld-options"
  "warning: ignoring untrusted substituter 'https://mukn.cachix.org'\n-L/nix/store/48j7nq0gv67irfa2ydfd4drbmalfxzni-secp256k1-unstable-2021-06-06/lib -lsecp256k1"
  "-cc-options"
  "warning: ignoring untrusted substituter 'https://mukn.cachix.org'\n-I/nix/store/48j7nq0gv67irfa2ydfd4drbmalfxzni-secp256k1-unstable-2021-06-06/include")
 ....)
 ```