### PR TITLE
Add new assert!! and assert!/where forms

### DIFF
--- a/assert.ss
+++ b/assert.ss
@@ -18,3 +18,26 @@
     (warn-and-err "Comparison failed: (~s ~s ~s)\n first value was: ~s\n second value was: ~s\n"
              pred-name expr1 expr2 val1 val2)
     (error "Comparison failed" pred-name expr1 expr2 val1 val2)))
+
+;; --------------------------------------------------------
+
+(defrules assert!/where
+  ((_ condition message (name expr) ...)
+   (let ((name expr) ...)
+     (assert!/where-helper condition message 'condition [(cons 'name name) ...]))))
+
+(defrules assert! ()
+  ((_ condition message expr ...)
+   (assert!/where-helper condition message 'condition [(cons 'expr expr) ...]))
+  ((_ condition message)
+   (unless expr
+     (error "Assertion failed" message 'expr)))
+  ((_ condition)
+   (unless expr
+     (error "Assertion failed" 'expr))))
+
+(def (assert!/where-helper condition message condition-expr extras)
+  (unless condition
+    (def hd (format "Assertion failed ~a: ~s" message condition-expr))
+    (def str (apply string-append hd (map (match <> ((cons k v) (format "\n  ~s => ~r" k v))) extras)))
+    (error str)))

--- a/assert.ss
+++ b/assert.ss
@@ -4,7 +4,7 @@
 (export #t)
 
 (import
-  (for-syntax :gerbil/expander)
+  (for-syntax (only-in :gerbil/expander core-bound-identifier?))
   :std/logger :std/sugar :std/format
   ./base ./error)
 

--- a/assert.ss
+++ b/assert.ss
@@ -4,7 +4,8 @@
 (export #t)
 
 (import
-  :std/logger :std/sugar
+  (for-syntax :gerbil/expander)
+  :std/logger :std/sugar :std/format
   ./base ./error)
 
 (defrules assert-comparison! ()
@@ -21,23 +22,53 @@
 
 ;; --------------------------------------------------------
 
-(defrules assert!/where
+(defrules assert!/where ()
   ((_ condition message (name expr) ...)
    (let ((name expr) ...)
      (assert!/where-helper condition message 'condition [(cons 'name name) ...]))))
 
-(defrules assert! ()
-  ((_ condition message expr ...)
-   (assert!/where-helper condition message 'condition [(cons 'expr expr) ...]))
-  ((_ condition message)
-   (unless expr
-     (error "Assertion failed" message 'expr)))
-  ((_ condition)
-   (unless expr
-     (error "Assertion failed" 'expr))))
+(begin-syntax
+  ;; original idea from Jack Firth, Sam Phillips, and Alex Knauth for Rackunit:
+  ;; https://github.com/racket/rackunit/issues/149#issuecomment-919208710
+  ;; special-identifier? : Any -> Bool
+  (def (special-identifier? stx)
+    (and (identifier? stx)
+         (or (core-bound-identifier? stx)
+             (and (syntax-local-value stx false) #t))))
+
+  ;; split-sub-exprs : Stx -> [Stx [[Id Stx] ...]]
+  (def (split-sub-exprs stx)
+    (syntax-case stx ()
+      ((f a ...)
+       (not (special-identifier? #'f))
+       (with-syntax (((x ...) (gentemps #'(a ...))))
+         [(syntax/loc stx (f x ...)) #'((x a) ...)]))
+      (_ [stx []])))
+
+  ;; srcloc-string : Stx -> String
+  (def (srcloc-string stx)
+    (def loc (stx-source stx))
+    (cond (loc (call-with-output-string "" (cut ##display-locat loc #t <>)))
+          (else "?"))))
+
+(defsyntax assert!!
+  (lambda (stx)
+    (syntax-case stx ()
+      ((_ condition)
+       (with-syntax (((c ((x e) ...)) (split-sub-exprs #'condition))
+                     (message (srcloc-string #'condition)))
+         #'(let ((x e) ...)
+             (assert!/where-helper c 'message 'condition [(cons 'e x) ...]))))
+      ((_ condition message)
+       (with-syntax (((c ((x e) ...)) (split-sub-exprs #'condition)))
+         #'(let ((x e) ...)
+             (assert!/where-helper c message 'condition [(cons 'e x) ...]))))
+      ((_ condition message expr ...)
+       #'(assert!/where-helper condition message 'condition [(cons 'expr expr) ...])))))
 
 (def (assert!/where-helper condition message condition-expr extras)
   (unless condition
+   (let ()
     (def hd (format "Assertion failed ~a: ~s" message condition-expr))
     (def str (apply string-append hd (map (match <> ((cons k v) (format "\n  ~s => ~r" k v))) extras)))
-    (error str)))
+    (error str))))

--- a/t/assert-test.ss
+++ b/t/assert-test.ss
@@ -1,0 +1,19 @@
+(export assert-test)
+
+(import
+  :std/test :std/pregexp
+  ../assert)
+
+(def assert-test
+  (test-suite "test suite for clan/assert"
+    (test-case "test assert!! form"
+      (def e 'needle)
+      (def l ['stack 'of 'hay])
+      (check-exception (assert!! (member e l))
+                       (lambda (e)
+                         (pregexp-match
+                          (string-append
+                           "Assertion failed \"t/assert-test.ss\"@12.34: \\(member e l\\)\n"
+                           "  e => 'needle\n"
+                           "  l => \\['stack 'of 'hay\\]\n")
+                          (error-message e)))))))


### PR DESCRIPTION
Add new `assert!!` and `assert!/where` forms, for better assertion failure messages than standard `assert!`, with a printing style after the message similar to the output of `DBG`.