### PR TITLE
import :std/assert

### DIFF
--- a/bcsv.ss
+++ b/bcsv.ss
@@ -55,7 +55,7 @@
   (for-syntax :std/stxutil)
   :gerbil/gambit/bytes
   :scheme/base-ports
-  :std/error :std/iter :std/misc/list :std/srfi/1 :std/srfi/43 :std/stxparam :std/sugar :std/assert
+  :std/assert :std/error :std/iter :std/misc/list :std/srfi/1 :std/srfi/43 :std/stxparam :std/sugar
   ./bytestring)
 
 ; -----------------------------------------------------------------------------

--- a/bcsv.ss
+++ b/bcsv.ss
@@ -55,7 +55,7 @@
   (for-syntax :std/stxutil)
   :gerbil/gambit/bytes
   :scheme/base-ports
-  :std/error :std/iter :std/misc/list :std/srfi/1 :std/srfi/43 :std/stxparam :std/sugar
+  :std/error :std/iter :std/misc/list :std/srfi/1 :std/srfi/43 :std/stxparam :std/sugar :std/assert
   ./bytestring)
 
 ; -----------------------------------------------------------------------------

--- a/bytestring.ss
+++ b/bytestring.ss
@@ -4,7 +4,7 @@
 (import
   :gerbil/gambit/bytes
   :scheme/base-ports
-  :std/iter :std/misc/list :std/srfi/43 :std/sugar :std/assert)
+  :std/assert :std/iter :std/misc/list :std/srfi/43 :std/sugar)
 
 (def (byte? x)
   (and (fixnum? x) (<= 0 x 255)))

--- a/bytestring.ss
+++ b/bytestring.ss
@@ -4,7 +4,7 @@
 (import
   :gerbil/gambit/bytes
   :scheme/base-ports
-  :std/iter :std/misc/list :std/srfi/43 :std/sugar)
+  :std/iter :std/misc/list :std/srfi/43 :std/sugar :std/assert)
 
 (def (byte? x)
   (and (fixnum? x) (<= 0 x 255)))

--- a/concurrency.ss
+++ b/concurrency.ss
@@ -6,8 +6,8 @@
 (import
   :gerbil/gambit/bytes :gerbil/gambit/continuations
   :gerbil/gambit/random :gerbil/gambit/threads
-  :std/actor :std/error :std/format :std/logger
-  :std/misc/bytes :std/misc/completion :std/misc/list :std/misc/repr :std/sugar :std/assert
+  :std/actor :std/assert :std/error :std/format :std/logger
+  :std/misc/bytes :std/misc/completion :std/misc/list :std/misc/repr :std/sugar
   ./base ./error ./exception)
 
 (deflogger clan)

--- a/concurrency.ss
+++ b/concurrency.ss
@@ -7,7 +7,7 @@
   :gerbil/gambit/bytes :gerbil/gambit/continuations
   :gerbil/gambit/random :gerbil/gambit/threads
   :std/actor :std/error :std/format :std/logger
-  :std/misc/bytes :std/misc/completion :std/misc/list :std/misc/repr :std/sugar
+  :std/misc/bytes :std/misc/completion :std/misc/list :std/misc/repr :std/sugar :std/assert
   ./base ./error ./exception)
 
 (deflogger clan)

--- a/decimal.ss
+++ b/decimal.ss
@@ -3,7 +3,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/exact
   :scheme/base-impl
-  :std/error :std/iter :std/misc/number :std/srfi/13 :std/sugar :std/assert
+  :std/assert :std/error :std/iter :std/misc/number :std/srfi/13 :std/sugar
   ./base ./basic-parsers ./basic-printers ./number ./string)
 
 ;; : Bool <- Any

--- a/decimal.ss
+++ b/decimal.ss
@@ -3,7 +3,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/exact
   :scheme/base-impl
-  :std/error :std/iter :std/misc/number :std/srfi/13 :std/sugar
+  :std/error :std/iter :std/misc/number :std/srfi/13 :std/sugar :std/assert
   ./base ./basic-parsers ./basic-printers ./number ./string)
 
 ;; : Bool <- Any

--- a/diceware.ss
+++ b/diceware.ss
@@ -9,7 +9,7 @@
 
 (import
   :gerbil/gambit/random
-  :std/format :std/iter :std/misc/list :std/misc/ports :std/pregexp :std/srfi/13 :std/sugar :std/assert
+  :std/assert :std/format :std/iter :std/misc/list :std/misc/ports :std/pregexp :std/srfi/13 :std/sugar
   ./base ./basic-parsers ./basic-printers ./basic-parsers ./number ./random)
 
 (def diceware-file (getenv "DICEWARE_FILE" #f))

--- a/diceware.ss
+++ b/diceware.ss
@@ -9,7 +9,7 @@
 
 (import
   :gerbil/gambit/random
-  :std/format :std/iter :std/misc/list :std/misc/ports :std/pregexp :std/srfi/13 :std/sugar
+  :std/format :std/iter :std/misc/list :std/misc/ports :std/pregexp :std/srfi/13 :std/sugar :std/assert
   ./base ./basic-parsers ./basic-printers ./basic-parsers ./number ./random)
 
 (def diceware-file (getenv "DICEWARE_FILE" #f))

--- a/extensible-vector.ss
+++ b/extensible-vector.ss
@@ -5,7 +5,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
-  :std/misc/bytes :std/srfi/43 :std/sugar
+  :std/misc/bytes :std/srfi/43 :std/sugar :std/assert
   ./number)
 
 (defstruct evector (values fill-pointer) transparent: #t)

--- a/extensible-vector.ss
+++ b/extensible-vector.ss
@@ -5,7 +5,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
-  :std/misc/bytes :std/srfi/43 :std/sugar :std/assert
+  :std/assert :std/misc/bytes :std/srfi/43 :std/sugar
   ./number)
 
 (defstruct evector (values fill-pointer) transparent: #t)

--- a/io.ss
+++ b/io.ss
@@ -1,7 +1,7 @@
 (export #t)
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/ports
-  :std/misc/bytes :std/sugar :std/assert
+  :std/assert :std/misc/bytes :std/sugar
   ./base ./number)
 
 ;;(def (write-u8vector v p) (write-subu8vector v 0 (u8vector-length v) p))

--- a/io.ss
+++ b/io.ss
@@ -1,7 +1,7 @@
 (export #t)
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/ports
-  :std/misc/bytes :std/sugar
+  :std/misc/bytes :std/sugar :std/assert
   ./base ./number)
 
 ;;(def (write-u8vector v p) (write-subu8vector v 0 (u8vector-length v) p))

--- a/net/whois.ss
+++ b/net/whois.ss
@@ -2,7 +2,7 @@
 (export #t)
 
 (import
-  :std/format :std/misc/list :std/misc/ports :std/misc/process :std/pregexp :std/srfi/1 :std/sugar
+  :std/format :std/misc/list :std/misc/ports :std/misc/process :std/pregexp :std/srfi/1 :std/sugar :std/assert
   ../assert ../base ../list)
 
 (def (valid-domain? name)

--- a/net/whois.ss
+++ b/net/whois.ss
@@ -2,7 +2,7 @@
 (export #t)
 
 (import
-  :std/format :std/misc/list :std/misc/ports :std/misc/process :std/pregexp :std/srfi/1 :std/sugar :std/assert
+  :std/assert :std/format :std/misc/list :std/misc/ports :std/misc/process :std/pregexp :std/srfi/1 :std/sugar
   ../assert ../base ../list)
 
 (def (valid-domain? name)

--- a/number.ss
+++ b/number.ss
@@ -6,7 +6,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
   :scheme/base
-  :std/misc/bytes :std/sugar :std/assert
+  :std/assert :std/misc/bytes :std/sugar
   ./base ./ports)
 
 ;;;; Numbers

--- a/number.ss
+++ b/number.ss
@@ -6,7 +6,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
   :scheme/base
-  :std/misc/bytes :std/sugar
+  :std/misc/bytes :std/sugar :std/assert
   ./base ./ports)
 
 ;;;; Numbers

--- a/prime.ss
+++ b/prime.ss
@@ -8,7 +8,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/exact :gerbil/gambit/misc :gerbil/gambit/random
   :scheme/base-impl
-  :std/iter :std/misc/list-builder :std/misc/number :std/srfi/1 :std/sugar
+  :std/iter :std/misc/list-builder :std/misc/number :std/srfi/1 :std/sugar :std/assert
   ./number ./extensible-vector)
 
 ;; Given a list of `primes`, return a vector the size of which is the product M of those primes,

--- a/prime.ss
+++ b/prime.ss
@@ -8,7 +8,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/exact :gerbil/gambit/misc :gerbil/gambit/random
   :scheme/base-impl
-  :std/iter :std/misc/list-builder :std/misc/number :std/srfi/1 :std/sugar :std/assert
+  :std/assert :std/iter :std/misc/list-builder :std/misc/number :std/srfi/1 :std/sugar
   ./number ./extensible-vector)
 
 ;; Given a list of `primes`, return a vector the size of which is the product M of those primes,

--- a/rpm-versioning.ss
+++ b/rpm-versioning.ss
@@ -2,7 +2,7 @@
 
 (export #t)
 (import
-  :std/misc/list :std/pregexp :std/srfi/13 :std/sugar :std/assert
+  :std/assert :std/misc/list :std/pregexp :std/srfi/13 :std/sugar
   ./base ./basic-parsers ./order ./pred)
 
 (def (valid-rpm-version-component? string start: (start 0) end: (end (string-length string)))

--- a/rpm-versioning.ss
+++ b/rpm-versioning.ss
@@ -2,7 +2,7 @@
 
 (export #t)
 (import
-  :std/misc/list :std/pregexp :std/srfi/13 :std/sugar
+  :std/misc/list :std/pregexp :std/srfi/13 :std/sugar :std/assert
   ./base ./basic-parsers ./order ./pred)
 
 (def (valid-rpm-version-component? string start: (start 0) end: (end (string-length string)))

--- a/subtitles.ss
+++ b/subtitles.ss
@@ -6,7 +6,7 @@
 (import
   :gerbil/gambit/exact
   :scheme/base-impl :scheme/char
-  :std/error :std/misc/list :std/misc/number :std/misc/string :std/srfi/13 :std/sugar
+  :std/error :std/misc/list :std/misc/number :std/misc/string :std/srfi/13 :std/sugar :std/assert
   ./base ./basic-parsers ./files ./number)
 
 (def (expect-srt-time-offset port)

--- a/subtitles.ss
+++ b/subtitles.ss
@@ -6,7 +6,7 @@
 (import
   :gerbil/gambit/exact
   :scheme/base-impl :scheme/char
-  :std/error :std/misc/list :std/misc/number :std/misc/string :std/srfi/13 :std/sugar :std/assert
+  :std/assert :std/error :std/misc/list :std/misc/number :std/misc/string :std/srfi/13 :std/sugar
   ./base ./basic-parsers ./files ./number)
 
 (def (expect-srt-time-offset port)

--- a/timestamp.ss
+++ b/timestamp.ss
@@ -7,7 +7,7 @@
 (import
   :gerbil/gambit/exact :gerbil/gambit/threads
   :scheme/base
-  :std/format :std/misc/number :std/srfi/19 :std/sugar :std/assert
+  :std/assert :std/format :std/misc/number :std/srfi/19 :std/sugar
   ./base ./basic-parsers ./number)
 
 ;; We deal with several time representations:

--- a/timestamp.ss
+++ b/timestamp.ss
@@ -7,7 +7,7 @@
 (import
   :gerbil/gambit/exact :gerbil/gambit/threads
   :scheme/base
-  :std/format :std/misc/number :std/srfi/19 :std/sugar
+  :std/format :std/misc/number :std/srfi/19 :std/sugar :std/assert
   ./base ./basic-parsers ./number)
 
 ;; We deal with several time representations:


### PR DESCRIPTION
After https://github.com/vyzo/gerbil/pull/644, `assert!` has been moved from `:std/sugar` to a new module `:std/assert`, so we need to import `:std/assert`.