### PR TITLE
timestamp-test: check-predicate

### DIFF
--- a/t/timestamp-test.ss
+++ b/t/timestamp-test.ss
@@ -18,4 +18,4 @@
                               (λ () (increment! counter)
                                  (when (> (current-tai-timestamp) target)
                                    (break counter)))))))
-        (check-equal? (<= 19 count-for-one-second 21) #t)))))
+        (check-predicate count-for-one-second (λ (x) (<= 19 x 21)))))))


### PR DESCRIPTION
To improve the test failure message from this which does not show the value:
```
Test case: Check periodically
... check (<= 19 count-for-one-second 21) is equal? to #t
*** FAILED: (check equal? (<= 19 count-for-one-second 21) #t) at "t/timestamp-test.ss"@21.23; value: #f
*** Test FAILED
```

To this which shows that the value is `11`:
```
Test case: Check periodically
... check count-for-one-second is (λ (x) (<= 19 x 21))
*** FAILED: (check-predicate count-for-one-second (λ (x) (<= 19 x 21))) at "t/timestamp-test.ss"@21.26; value: 11
*** Test FAILED
```