### PR TITLE
Add :clan/net/tcp module

### DIFF
--- a/concurrency.ss
+++ b/concurrency.ss
@@ -212,8 +212,8 @@
 
 ;; Retry a thunk until it either succeeds or fails,
 ;; with an exponential back off that is capped to constant back off.
-;; max-retries: real number, in seconds, (+inf.0 for unlimited),
-;;   maximum number of times to retry the action.
+;; max-retries: real number, number of retries, (+inf.0 for unlimited),
+;;   ceiling is the maximum number of times to retry the action.
 ;; max-window: real number, in seconds, (+inf.0 for unlimited),
 ;;  maximum window within which to retry the action
 ;; retry-window: real number, in seconds,
@@ -236,8 +236,8 @@
 
 ;; Retry a function until it either succeeds or calls its failure argument,
 ;; with an exponential back off that is capped to constant back off.
-;; max-retries: real number, in seconds, (+inf.0 for unlimited),
-;;   maximum number of times to retry the action.
+;; max-retries: real number, number of retries, (+inf.0 for unlimited),
+;;   ceiling is the maximum number of times to retry the action.
 ;; max-window: real number, in seconds, (+inf.0 for unlimited),
 ;;  maximum window within which to retry the action
 ;; retry-window: real number, in seconds,

--- a/net/t/tcp-integrationtest.ss
+++ b/net/t/tcp-integrationtest.ss
@@ -1,0 +1,114 @@
+
+(export tcp-integrationtest)
+
+(import :gerbil/gambit/ports :gerbil/gambit/threads
+        :std/iter :std/sugar :std/test :std/text/json
+        :clan/concurrency :clan/json :clan/timestamp
+        ../tcp)
+
+(def tcp-integrationtest
+  (test-suite "test suite for clan/net/tcp"
+    (test-case "tcp line chat"
+      (def (write-line str out)
+        (display str out)
+        (newline out)
+        (force-output out))
+
+      ;; start client first to test retry-until-deadline
+      (def client
+        (spawn/name/logged
+          'client
+          (lambda ()
+            (def deadline (+ (current-unix-time) 10))
+            (def port (tcp-connect/retry-until-deadline [address: "localhost" port-number: 8000] deadline (lambda () #f)))
+            (check-predicate port tcp-client-port?)
+            (write-line "hello" port)
+            (check-equal? (read-line port) "hi")
+            (write-line "fruit?" port)
+            (check-equal? (read-line port) "no")
+            (check-equal? (read-line port) "bread?")
+            (write-line "no" port)
+            (write-line "fruit & bread?" port)
+            (check-equal? (read-line port) "probably not")
+            (check-equal? (read-line port) "do you like rectangles?")
+            (write-line "mmm, my favorite thing to have for breakfast!" port)
+            (check-equal? (read-line port) "yeah")
+            (write-line "okay" port)
+            (write-line "bye" port)
+            (close-output-port port)
+            (check-predicate (read-line port) eof-object?)
+            (close-input-port port)
+            #t)))
+
+      ;; have server sleep to test retry-until-deadline
+      (def server
+        (spawn/name/logged
+          'server
+          (lambda ()
+            (thread-sleep! 1)
+            (def listener (tcp-listen [local-port-number: 8000]))
+            (check-predicate listener tcp-listener?)
+            (def port (tcp-accept listener))
+            (check-predicate port tcp-client-port?)
+            (check-equal? (read-line port) "hello")
+            (write-line "hi" port)
+            (check-equal? (read-line port) "fruit?")
+            (write-line "no" port)
+            (write-line "bread?" port)
+            (check-equal? (read-line port) "no")
+            (check-equal? (read-line port) "fruit & bread?")
+            (write-line "probably not" port)
+            (write-line "do you like rectangles?" port)
+            (check-equal? (read-line port) "mmm, my favorite thing to have for breakfast!")
+            (write-line "yeah" port)
+            (check-equal? (read-line port) "okay")
+            (check-equal? (read-line port) "bye")
+            (close-output-port port)
+            (check-predicate (read-line port) eof-object?)
+            (close-input-port port)
+            (tcp-close listener)
+            #t)))
+      (check-equal? (thread-join! client) #t)
+      (check-equal? (thread-join! server) #t))
+
+    (test-case "tcp json countdown"
+      ;; start client first to test retry-until-deadline
+      (def client
+        (spawn/name/logged
+          'client
+          (lambda ()
+            (def deadline (+ (current-unix-time) 10))
+            (def port (tcp-connect/retry-until-deadline [address: "localhost" port-number: 8000] deadline (lambda () #f)))
+            (write-json-ln (hash (C 1) (E 3) (G 5)) port)
+            (write-json-ln (hash (B 7) (D 2) (G 5)) port)
+            (write-json-ln (hash (C 1) (E 3) (A 6)) port)
+            (write-json-ln (hash (C 1) (F 4) (A 6)) port)
+            (write-json-ln (hash (C 1) (E 3) (G 5) (B 7)) port)
+            (close-output-port port)
+            (begin0
+              (read-all port read-json)
+              (close-input-port port)))))
+
+      ;; have server sleep to test retry-until-deadline
+      (def server
+        (spawn/name/logged
+          'server
+          (lambda ()
+            (thread-sleep! 1)
+            (def listener (tcp-listen [local-port-number: 8000]))
+            (def port (tcp-accept listener))
+            (def js (read-all port read-json))
+            (for ((j js)
+                  (i (in-range (1- (length js)) -1 -1)))
+                (write-json-ln [i j] port))
+            (force-output port)
+            (close-port port)
+            (tcp-close listener))))
+      (thread-join! server)
+      (check-equal? (json-object->string (thread-join! client))
+                    (json-object->string
+                     [[4 (hash (C 1) (E 3) (G 5))]
+                      [3 (hash (B 7) (D 2) (G 5))]
+                      [2 (hash (C 1) (E 3) (A 6))]
+                      [1 (hash (C 1) (F 4) (A 6))]
+                      [0 (hash (C 1) (E 3) (G 5) (B 7))]])))))

--- a/net/t/tcp-integrationtest.ss
+++ b/net/t/tcp-integrationtest.ss
@@ -84,6 +84,7 @@
             (write-json-ln (hash (C 1) (E 3) (A 6)) port)
             (write-json-ln (hash (C 1) (F 4) (A 6)) port)
             (write-json-ln (hash (C 1) (E 3) (G 5) (B 7)) port)
+            (force-output port)
             (close-output-port port)
             (begin0
               (read-all port read-json)

--- a/net/tcp.ss
+++ b/net/tcp.ss
@@ -1,0 +1,94 @@
+
+(export tcp-listener?
+        tcp-listen
+        tcp-client-port?
+        tcp-connect
+        tcp-accept
+        tcp-close
+        try-tcp-connect
+        tcp-connect/retry-until-deadline)
+
+(import :gerbil/gambit/exceptions :gerbil/gambit/ports :gerbil/gambit/threads
+        :std/format :std/pregexp :std/sugar
+        :clan/base :clan/timestamp)
+
+;; --------------------------------------------------------
+
+;; Listeners and connections with SYN/ACC
+
+(def SYN 22)
+(def ACK 6)
+(def (syn/ack port)
+  (write-u8 SYN port)
+  (force-output port)
+  (and
+    (equal? (read-u8 port) SYN)
+    (begin
+      (write-u8 ACK port)
+      (force-output port)
+      (equal? (read-u8 port) ACK))))
+
+;; A Tcp-Listener is a (tcp-listener Tcp-Server-Port)
+(defstruct tcp-listener (port))
+
+;; tcp-listen : PortAddressSettings -> Tcp-Listener
+(def (tcp-listen port-addr-settings)
+  (tcp-listener (open-tcp-server port-addr-settings)))
+
+;; tcp-connect : PortAddressSettings -> Tcp-Client-Port
+(def (tcp-connect port-addr-settings)
+  (def port (open-tcp-client port-addr-settings))
+  (unless (syn/ack port) (error "tcp-connect: SYN/ACK failed"))
+  port)
+
+;; tcp-accept : Tcp-Listener -> Tcp-Client-Port
+(def (tcp-accept listener)
+  (def port (read (tcp-listener-port listener)))
+  (unless (syn/ack port) (error "tcp-accept: SYN/ACK failed"))
+  port)
+
+;; tcp-close : Tcp-Listener -> Void
+(def (tcp-close listener)
+  (close-port (tcp-listener-port listener)))
+
+;; try-tcp-connect : PortAddressSettings (-> Fail) -> Tcp-Client-Port | Fail
+(def (try-tcp-connect port-addr-settings failure)
+  (def port (try-open-tcp-client port-addr-settings (lambda () #f)))
+  (cond
+    ((not port) (failure))
+    ((try (syn/ack port) (catch (os-exception:tcp-client-port? e) #f)) port)
+    (else (ignore-errors (close-port port)) (failure))))
+
+(def (tcp-connect/retry-until-deadline port-addr-settings deadline failure)
+  (let loop ()
+    (try-tcp-connect port-addr-settings
+      (lambda ()
+        (cond ((> (current-unix-time) deadline) (failure))
+              (else (thread-sleep! 1) (loop)))))))
+
+;; --------------------------------------------------------
+
+;; Gambit's tcp client ports
+
+;; from gambit lib/_io#.scm
+;; definition of macro-tcp-client-kind
+(def TCP_CLIENT_PORT_KIND (+ 31 512))
+
+;; try-open-tcp-client : PortAddressSettings (-> Fail) -> Tcp-Client-Port | Fail
+(def (try-open-tcp-client addr-info failure)
+  (try
+    (open-tcp-client addr-info)
+    (catch (os-exception:tcp-client-port? e) (failure))))
+
+;; os-exception:tcp-client-port? : Any -> Bool
+(def (os-exception:tcp-client-port? e)
+  (and (os-exception? e)
+       (ormap tcp-client-port? (os-exception-arguments e))))
+
+;; tcp-client-port? : Any -> Bool
+(def (tcp-client-port? v)
+  (and (input-port? v)
+       (output-port? v)
+       (##port-of-kind? v TCP_CLIENT_PORT_KIND)))
+
+;; --------------------------------------------------------


### PR DESCRIPTION
The function `tcp-listen` creates a tcp-listener for a server.

The function `tcp-connect` creates a tcp-client-port to connect to a server.

The function `tcp-accept` takes a tcp-listener and allows a connection to come in, creating a tcp-client-port for the server to use to talk to the client that connected.

The function `tcp-connect/retry-until-deadline` keeps trying `try-tcp-connect` every second until it works, or until the deadline passes.